### PR TITLE
Ignore files that should not be in the package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,3 @@
+^.*\.Rproj$
+LICENSE.md
+^images\/


### PR DESCRIPTION
.Rbuildignore will make sure that the files listed do not end up in the .tar.gz file.